### PR TITLE
Chapter 12：SSMで秘匿情報を管理、ECSタスク定義の環境変数から参照

### DIFF
--- a/container_definitions_batch.json
+++ b/container_definitions_batch.json
@@ -3,6 +3,7 @@
     "name": "alpine",
     "image": "alpine:latest",
     "essential": true,
+    "environment": [],
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
@@ -11,6 +12,20 @@
         "awslogs-stream-prefix": "batch"
       }
     },
-    "command": ["/bin/date"]
+    "mountPoints": [],
+    "secrets": [
+      {
+        "name": "DB_USERNAME",
+        "valueFrom": "/db/username"
+      },
+      {
+        "name": "DB_PASSWORD",
+        "valueFrom": "/db/password"
+      }
+    ],
+    "command": ["/usr/bin/env"],
+    "portMappings": [],
+    "systemControls": [],
+    "volumesFrom": []
   }
 ]

--- a/ssm.tf
+++ b/ssm.tf
@@ -1,0 +1,18 @@
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter
+resource "aws_ssm_parameter" "db_username" {
+  name        = "/db/username"
+  value       = "root"
+  type        = "String"
+  description = "Database username"
+}
+
+resource "aws_ssm_parameter" "db_raw_password" {
+  name        = "/db/password"
+  value       = "password"
+  type        = "SecureString"
+  description = "Database password"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}


### PR DESCRIPTION
## やったこと

- AWS Systems Manager (SSM) のパラメータストアで秘匿情報を管理
- AWS CLIから秘匿情報を上書き（Terraformで管理しない）
  ```
  aws ssm put-parameter --name '/db/password' --type SecureString --value '<password>' --overwrite
  ```
- ECSタスク定義の環境変数からパラメータを参照

## 成果

パラメータストア
![image](https://github.com/user-attachments/assets/407ba7c5-5516-49ed-9520-03fce4dedf3a)

ECSタスクから環境変数を出力したログ
![スクリーンショット 2024-12-15 19 14 16](https://github.com/user-attachments/assets/62a7cb22-1a66-47be-95f7-52dac4ced049)
